### PR TITLE
use `locate-user-emacs-file` to specify default save file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ In init.el, you can add settings as bellow.
 (add-hook 'SOME-MODE-hook 'phantom-inline-comment-auto-restore-mode)
 ```
 
-It allows you to save all the comments into the data-file (default `~/.phantom-inline-comments`), before you quit Emacs.  
+It allows you to save all the comments into the data-file
+(default `~/.emacs.d/pahtnom-inline-comment` or `~/.phantom-inline-comment` if it exists), before you quit Emacs.  
 And when you open the file you added comments, automatically the data-file will be loaded and the comments will be added again.
 

--- a/phantom-inline-comment.el
+++ b/phantom-inline-comment.el
@@ -45,7 +45,8 @@
 (defvar phantom-inline-comment-edit-buffer "*phantom-inline-comment-edit*")
 (defvar phantom-inline-comment-show-buffer "*phantom-inline-comments*")
 
-(defvar phantom-saved-file "~/.phantom-inline-comments")
+(defvar phantom-saved-file
+  (locate-user-emacs-file "phantom-inline-comments" ".phantom-inline-comments"))
 
 (defvar phantom-inline-comment-state nil) ;; 'add or 'edit
 (defvar phantom-inline-comment-visibility 'show) ;; 'hide or 'show


### PR DESCRIPTION
Hi! This package is awesome!
I found a small issue as the Elisp package, I fix it.

---

It is recommended that Elisp packages save files in user-emacs-directory.
The default value for it is `~/.emacs.d/`, and it has been changed by the user,
`locate-user-emacs-file` is returns path in consideration of the change.

And `locate-user-emacs-file` returns previous path if file exist in HOME,
this change is not destructive.

cf: http://emacs.rubikitch.com/new-files/

Best,